### PR TITLE
Correct examples freq vs frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import morfeus
 
 mrf = morfeus.MoRFeus()
 mrf.mode = morfeus.Mode.MIXER
-mrf.frequency = 120000000
+mrf.freq = 120000000
 mrf.bias = 0
 mrf.current = 1
 ```
@@ -42,7 +42,7 @@ to the device over CLI. Usage is also easy as the API:
 $ morfeus mode
 MIXER
 $ morfeus mode GENERATOR
-$ morfeus frequency 120000000
+$ morfeus freq 120000000
 $ morfeus bias 0
 $ morfeus current 0
 ```

--- a/morfeus/device.py
+++ b/morfeus/device.py
@@ -8,7 +8,7 @@ Usage:
 
   mrf = morfeus.MoRFeus()
   mrf.mode = morfeus.Mode.GENERATOR
-  mrf.frequency = 120000000
+  mrf.freq = 120000000
 
 """
 


### PR DESCRIPTION
The examples and readme descibe the use like mrf.frequency = 120000000
This should be  mrf.freq = 120000000